### PR TITLE
adding retry logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    circactivator (2.0.1)
+    circactivator (2.1.0)
       httparty (~> 0.13.3)
       mixlib-log (~> 1.6.0)
       settingslogic (~> 2.0.9)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ circonus:
     base_url: https://api.circonus.com/v2
     api_key: your-api-key-here
     api_app_name: circactivator
+    verify: false
+    attempts: 3
 
 monitoring:
     error_file: /path/to/log/file/circactivator.err
@@ -72,7 +74,7 @@ The `log` section of the config sets up the log file CircActivator uses to log i
 
 ### Circonus
 
-The `circonus` section of the config specifies which Circonus instance to use (which is especially useful if you are a Circonus Inside customer) and your API key and app name.  See https://login.circonus.com/resources/api#authentication for more information.
+The `circonus` section of the config specifies which Circonus instance to use (which is especially useful if you are a Circonus Inside customer) and your API key and app name.  See https://login.circonus.com/resources/api#authentication for more information.  Additionally, you may disable SSL validation with the `verify: false` config item (in the event you're running a Circonus Inside system using an untrusted CA), and how many times CircActivator will try an API call upon failure or timeout (defaults to 3).
 
 ### Monitoring
 

--- a/lib/circactivator/checkupdater.rb
+++ b/lib/circactivator/checkupdater.rb
@@ -54,7 +54,7 @@ module CircActivator
 
     def call_circonus(method, url, options={})
       options[:headers] = http_headers
-      options[:verify]  = CircActivator::Config.circonus['verify'] || true
+      options[:verify]  = CircActivator::Config.circonus.fetch('verify', true)
 
       attempt = 0
       begin

--- a/spec/support/fixtures/config/config.yml
+++ b/spec/support/fixtures/config/config.yml
@@ -7,6 +7,8 @@ circonus:
     base_url: https://api.circonus.com/v2
     api_key: a12345
     api_app_name: my_app
+    verify: false
+    attempts: 3
 
 monitoring:
     error_file: /Users/adam/tmp/circactivator.err

--- a/spec/support/fixtures/config/config.yml
+++ b/spec/support/fixtures/config/config.yml
@@ -1,5 +1,5 @@
 log:
-    file: /Users/adam/tmp/circactivator.log
+    file: log/circactivator.log
     level: debug
     count: 7
 
@@ -11,7 +11,7 @@ circonus:
     attempts: 3
 
 monitoring:
-    error_file: /Users/adam/tmp/circactivator.err
+    error_file: log/circactivator.err
 
 check_bundles:
     iad1-prod:


### PR DESCRIPTION
adding retry logic and related tests in the event of an API call failure or timeout.  Circonus API can sometimes return a 502 when it shouldn't, but a retry will likely succeed.
